### PR TITLE
#HT-150: Setup preliminary scaffold

### DIFF
--- a/packages/common/.mocharc.json
+++ b/packages/common/.mocharc.json
@@ -1,0 +1,6 @@
+{
+    "require": ["ts-node/register"],
+    "watch-files": ["./test/**/*.ts"],
+    "extension": ["ts"],
+    "recurisve": true
+}

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -1,0 +1,9 @@
+# Hypertool Common
+
+The Hypertool Common package contains type declarations, Mongoose models,
+utilities, and other constructs that are used by all the other packages.
+
+## License
+
+The open-source components of Hypertool are available under the
+[MIT license](https://opensource.org/licenses/MIT).

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -9,6 +9,7 @@
     "dependencies": {},
     "peerDependencies": {},
     "devDependencies": {
+        "@types/node": "^17.0.10",
         "typescript": "^4.5.4"
     }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -16,6 +16,7 @@
         "mongoose": "^6.1.7"
     },
     "devDependencies": {
+        "@types/chai": "^4.3.0",
         "@types/mocha": "^9.0.0",
         "@types/node": "^17.0.10",
         "chai": "^4.3.4",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -18,6 +18,7 @@
     "devDependencies": {
         "@types/mocha": "^9.0.0",
         "@types/node": "^17.0.10",
+        "chai": "^4.3.4",
         "mocha": "^9.1.4",
         "mongodb-memory-server": "^8.2.0",
         "mongoose": "^6.1.7",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -5,7 +5,10 @@
     "repository": "https://github.com/hypertool/hypertool",
     "private": false,
     "main": "./build/index.js",
-    "scripts": {},
+    "scripts": {
+        "watch": "tsc -w",
+        "build": "tsc"
+    },
     "dependencies": {},
     "peerDependencies": {
         "mongoose": "^6.1.7"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -7,7 +7,9 @@
     "main": "./build/index.js",
     "scripts": {
         "watch": "tsc -w",
-        "build": "tsc"
+        "build": "tsc",
+        "test": "mocha --config .mocharc.json ./test",
+        "test:watch": "mocha --config .mocharc.json --watch ./test"
     },
     "dependencies": {},
     "peerDependencies": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -7,9 +7,12 @@
     "main": "./build/index.js",
     "scripts": {},
     "dependencies": {},
-    "peerDependencies": {},
+    "peerDependencies": {
+        "mongoose": "^6.1.7"
+    },
     "devDependencies": {
         "@types/node": "^17.0.10",
+        "mongoose": "^6.1.7",
         "typescript": "^4.5.4"
     }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -14,6 +14,7 @@
         "mongoose": "^6.1.7"
     },
     "devDependencies": {
+        "@types/mocha": "^9.0.0",
         "@types/node": "^17.0.10",
         "mocha": "^9.1.4",
         "mongoose": "^6.1.7",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "@hypertool/common",
+    "version": "0.0.0",
+    "license": "MIT",
+    "repository": "https://github.com/hypertool/hypertool",
+    "private": false,
+    "main": "./build/index.js",
+    "scripts": {},
+    "devDependencies": {},
+    "dependencies": {},
+    "peerDependencies": {}
+}

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -17,6 +17,7 @@
         "@types/mocha": "^9.0.0",
         "@types/node": "^17.0.10",
         "mocha": "^9.1.4",
+        "mongodb-memory-server": "^8.2.0",
         "mongoose": "^6.1.7",
         "ts-node": "^10.4.0",
         "typescript": "^4.5.4"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -6,7 +6,9 @@
     "private": false,
     "main": "./build/index.js",
     "scripts": {},
-    "devDependencies": {},
     "dependencies": {},
-    "peerDependencies": {}
+    "peerDependencies": {},
+    "devDependencies": {
+        "typescript": "^4.5.4"
+    }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -15,6 +15,7 @@
     },
     "devDependencies": {
         "@types/node": "^17.0.10",
+        "mocha": "^9.1.4",
         "mongoose": "^6.1.7",
         "typescript": "^4.5.4"
     }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -18,6 +18,7 @@
         "@types/node": "^17.0.10",
         "mocha": "^9.1.4",
         "mongoose": "^6.1.7",
+        "ts-node": "^10.4.0",
         "typescript": "^4.5.4"
     }
 }

--- a/packages/common/test/index.ts
+++ b/packages/common/test/index.ts
@@ -1,0 +1,26 @@
+import dotenv from "dotenv";
+import mongoose from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import "chai/register-assert";
+
+dotenv.config({
+    path: `${__dirname}/../.env.test`,
+});
+
+before(async function () {
+    const mongo = await MongoMemoryServer.create();
+    await mongoose.connect(mongo.getUri(), {
+        dbName: "test",
+    });
+    this.mongo = mongo;
+});
+
+beforeEach(async function () {
+    await mongoose.connection.dropDatabase();
+});
+
+afterEach(async function () {});
+
+after(async function () {
+    await this.mongo.stop();
+});

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "esModuleInterop": true,
+        "target": "es6",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "outDir": "dist",
+        "allowJs": true
+    },
+    "include": ["./source/**/*.ts"],
+    "lib": ["es2015"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4715,6 +4715,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.19.tgz#1afa165146997b8286b6eabcb1c2d50729055169"
   integrity sha512-BPAcfDPoHlRQNKktbsbnpACGdypPFBuX4xQlsWDE7B8XXcfII+SpOLay3/qZmCLb39kV5S1RTYwXdkx2lwLYng==
 
+"@types/node@^17.0.10":
+  version "17.0.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.10.tgz#616f16e9d3a2a3d618136b1be244315d95bd7cab"
+  integrity sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6058,6 +6058,11 @@ assert@^1.1.1:
     object-assign "^4.1.1"
     util "0.10.3"
 
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
@@ -7006,6 +7011,18 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.1.0.tgz#246687debb6014735131be8abab2d93898f8d043"
   integrity sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==
 
+chai@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.4.tgz#b55e655b31e1eac7099be4c08c21964fce2e6c49"
+  integrity sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^3.0.1"
+    get-func-name "^2.0.0"
+    pathval "^1.1.1"
+    type-detect "^4.0.5"
+
 chalk@2.4.2, chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -7079,6 +7096,11 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
 check-types@^11.1.1:
   version "11.1.2"
@@ -8320,6 +8342,13 @@ dedent@0.7.0, dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
+
+deep-eql@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
+  dependencies:
+    type-detect "^4.0.0"
 
 deep-equal@^1.0.1:
   version "1.1.1"
@@ -10259,6 +10288,11 @@ get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
 
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
@@ -15262,6 +15296,11 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pathval@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
+
 pause@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/pause/-/pause-0.0.1.tgz#1d408b3fdb76923b9543d96fb4c9dfd535d9cb5d"
@@ -19096,7 +19135,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@4.0.8:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -14013,6 +14013,22 @@ mongoose@^6.0.12:
     sift "13.5.2"
     sliced "1.0.1"
 
+mongoose@^6.1.7:
+  version "6.1.7"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-6.1.7.tgz#fc1dfb792e0d2df52aa86064eb1a620d57b1926e"
+  integrity sha512-GqU/G/5yu/CWBHdW24cfGPsW4rADER+eeXj+bwvb6mLjg6uAASl8GnE6pmEbafZJ4Uv9V7jf5LaBMJMNwvQEtg==
+  dependencies:
+    "@types/node" "< 17.0.6"
+    bson "^4.2.2"
+    kareem "2.3.3"
+    mongodb "4.2.2"
+    mpath "0.8.4"
+    mquery "4.0.0"
+    ms "2.1.2"
+    regexp-clone "1.0.0"
+    sift "13.5.2"
+    sliced "1.0.1"
+
 morgan@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.10.0.tgz#091778abc1fc47cd3509824653dae1faab6b17d7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4415,6 +4415,11 @@
   dependencies:
     "@types/webpack" "^4"
 
+"@types/chai@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.0.tgz#23509ebc1fa32f1b4d50d6a66c4032d5b8eaabdc"
+  integrity sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==
+
 "@types/color-convert@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/color-convert/-/color-convert-2.0.0.tgz#8f5ee6b9e863dcbee5703f5a517ffb13d3ea4e22"


### PR DESCRIPTION
The Mongoose models and a few other symbols are common across different Hypertool packages. Maintaining different versions of the same symbol will be a pain in the long run. Therefore, all the common constructs need to be moved to `@hypertool/common` package.

In this PR, the preliminary scaffold for `@hypertool/common` was setup.